### PR TITLE
Recursive project file searching

### DIFF
--- a/crates/chain/src/project/packager.rs
+++ b/crates/chain/src/project/packager.rs
@@ -18,6 +18,8 @@ pub fn pack_server<P: AsRef<Path>>(root_directory: P, is_dev: bool) -> anyhow::R
     let server_directory = out_directory.join("server");
 
     let project = project::load_project(root_directory)?;
+    let project_directory = &project.root_directory;
+
     let settings = match project.get_settings(is_dev) {
         Ok(settings) => settings,
         Err(_) => {
@@ -41,7 +43,7 @@ pub fn pack_server<P: AsRef<Path>>(root_directory: P, is_dev: bool) -> anyhow::R
         server_directory.join("plugins"),
     )?;
 
-    project::process_files(settings.clone(), &server_directory)?;
+    project::process_files(project_directory, &server_directory, settings.clone())?;
 
     let server_jar = Path::new(&version.jar_file);
     let server_jar_name: &str = Path::new(&version.jar_file)

--- a/crates/chain/src/util/file.rs
+++ b/crates/chain/src/util/file.rs
@@ -22,3 +22,20 @@ pub fn append_or_check_file<P: AsRef<Path>>(path: P, file_name: &str) -> Option<
 
     Some(path_buf)
 }
+
+pub fn find_up_file(path: &Path, file_name: &str) -> Option<PathBuf> {
+    let mut path: PathBuf = path.into();
+    let file = Path::new(file_name);
+
+    loop {
+        path.push(file);
+
+        if path.is_file() {
+            break Some(path);
+        }
+
+        if !(path.pop() && path.pop()) {
+            break None;
+        }
+    }
+}


### PR DESCRIPTION
Chain will try to find the `chain.yml` file up the directory tree, and use its path as the project directory, instead of using the current directory of the terminal